### PR TITLE
Fix a few typos in Exercise 5

### DIFF
--- a/Instructions/Exercises/05-extract-custom-entities.md
+++ b/Instructions/Exercises/05-extract-custom-entities.md
@@ -214,7 +214,7 @@ Now you're ready to use the Azure AI Language service to extract custom entities
     ai_client = TextAnalyticsClient(endpoint=ai_endpoint, credential=credential)
     ```
 
-1. in the **Main** function, note that the existing code reads all of the files in the **articles** folder and creates a list containing their contents. In the case of the C# code, the a list of **TextDocumentInput** objects is used to include the file name as an ID and the language. In Python a simple list of the text contents is used.
+1. in the **Main** function, note that the existing code reads all of the files in the **ads** folder and creates a list containing their contents. In the case of the C# code, the a list of **TextDocumentInput** objects is used to include the file name as an ID and the language. In Python a simple list of the text contents is used.
 1. Find the comment **Extract entities** and add the following code:
 
     **C#**: Program.cs

--- a/Labfiles/05-custom-entity-recognition/Python/custom-entities/custom-entities.py
+++ b/Labfiles/05-custom-entity-recognition/Python/custom-entities/custom-entities.py
@@ -16,15 +16,16 @@ def main():
         # Create client using endpoint and key
 
 
-        # Read each text file in the reviews folder
+        # Read each text file in the ads folder
         batchedDocuments = []
-        articles_folder = 'ads'
-        files = os.listdir(articles_folder)
+        ads_folder = 'ads'
+        files = os.listdir(ads_folder)
         for file_name in files:
             # Read the file contents
-            text = open(os.path.join(articles_folder, file_name), encoding='utf8').read()
+            text = open(os.path.join(ads_folder, file_name), encoding='utf8').read()
             batchedDocuments.append(text)
 
+        # Extract entities
         
         
 


### PR DESCRIPTION
In this exercise, we're trying to extract entities from ad samples but the instructions (and the corresponding python code) sometimes mistakenly refer to them as articles (which were used in the 4th exercise).

It may feel just a little confusing to readers, the code runs perfectly fine otherwise.