### PR TITLE
Correcting minor spelling mistake.

### DIFF
--- a/Instructions/Exercises/03-language-understanding.md
+++ b/Instructions/Exercises/03-language-understanding.md
@@ -240,7 +240,7 @@ The Azure AI Language service provides a set of *prebuilt* entities that are com
 1. On the page for the **Date** entity, in the **Learned** section, ensure **Not required** is selected. Then, in the **Prebuilt** section, select **&#65291; Add new prebuilt**.
 
 1. In the **Select prebuilt** list, select **DateTime** and then select **Save**.
-1. After adding athe prebuilt entity, return to the **Data labeling** page
+1. After adding the prebuilt entity, return to the **Data labeling** page
 1. Select the **GetDay** intent and enter the following new example utterance:
 
     `what day was 01/01/1901?`


### PR DESCRIPTION
`the` was misspelt with a leading a.

Discovered it when I was following along the tutorials.