### PR TITLE
Update 07-speech.md

### DIFF
--- a/Instructions/Exercises/07-speech.md
+++ b/Instructions/Exercises/07-speech.md
@@ -183,7 +183,7 @@ Now that you have a **SpeechConfig** for the speech service in your Azure AI Spe
     **Python**
 
     ```
-    pip install playsound==1.3.0
+    pip install playsound==1.2.2
     ```
 
 1. In the code file for your program, under the existing namespace imports, add the following code to import the library you just installed:


### PR DESCRIPTION
playsound 1.3.0 throws an error 259 in the Skillable environment with a message of "The driver cannot recognize the specified command parameter.". Rolling back to 1.2.2 fixes the issue.