### PR TITLE
Fix small typo in lab 4 and lab 5

### DIFF
--- a/Instructions/Exercises/04-text-classification.md
+++ b/Instructions/Exercises/04-text-classification.md
@@ -185,7 +185,7 @@ Applications for both C# and Python have been provided, as well as a sample text
     - **C#**: appsettings.json
     - **Python**: .env
     
-1. Update the configuration values to include the  **endpoint** and a **key** from the Azure Language resource you created (available on the **Keys and Endpoint** page for your Azure AI Language resource in the Azure portal). The fil should already contain the project and deployment names for your text classification model.
+1. Update the configuration values to include the  **endpoint** and a **key** from the Azure Language resource you created (available on the **Keys and Endpoint** page for your Azure AI Language resource in the Azure portal). The file should already contain the project and deployment names for your text classification model.
 1. Save the configuration file.
 
 ## Add code to classify documents

--- a/Instructions/Exercises/05-extract-custom-entities.md
+++ b/Instructions/Exercises/05-extract-custom-entities.md
@@ -95,7 +95,7 @@ Now that your project is created, you need to label your data to train your mode
     1. Highlight the text *Denver, CO* and select the **Location** entity.
     1. Highlight the text *$90* and select the **Price** entity.
 1.In the **Activity** pane, note that this document will be added to the dataset for training the model.
-1. Us the **Next document** button to move to the next document, and continue assigning text to appropriate entities for the entire set of documents, adding them all to the training dataset.
+1. Use the **Next document** button to move to the next document, and continue assigning text to appropriate entities for the entire set of documents, adding them all to the training dataset.
 1. When you have labeled the last document (*Ad 9.txt*), save the labels.
 
 ## Train your model


### PR DESCRIPTION
Lab4: Section 'Configure you application': Step 4 should say `file`, not `fil`.
Lab5: Section 'Label your data': Step 6 should say `Use`, not `Us`.