### PR TITLE
LAB02 Q&A: The "quit" command in the clients (both C# and Python) doesn't exit immediately

### DIFF
--- a/Instructions/Exercises/02-qna.md
+++ b/Instructions/Exercises/02-qna.md
@@ -235,8 +235,10 @@ Now you're ready to add the code necessary to import the required SDK libraries,
     ```Python
     # Submit a question and display the answer
     user_question = ''
-    while user_question.lower() != 'quit':
+    while True:
         user_question = input('\nQuestion:\n')
+        if user_question.lower() == "quit":                
+            break
         response = ai_client.get_answers(question=user_question,
                                         project_name=ai_project_name,
                                         deployment_name=ai_deployment_name)

--- a/Instructions/Exercises/02-qna.md
+++ b/Instructions/Exercises/02-qna.md
@@ -212,10 +212,12 @@ Now you're ready to add the code necessary to import the required SDK libraries,
     ```C#
     // Submit a question and display the answer
     string user_question = "";
-    while (user_question.ToLower() != "quit")
+    while (true)
         {
             Console.Write("Question: ");
             user_question = Console.ReadLine();
+            if (user_question.ToLower() == "quit")
+                break;
             QuestionAnsweringProject project = new QuestionAnsweringProject(projectName, deploymentName);
             Response<AnswersResult> response = aiClient.GetAnswers(user_question, project);
             foreach (KnowledgeBaseAnswer answer in response.Value.Answers)


### PR DESCRIPTION
This pull request includes changes to improve the termination condition in the `while` loops for both C# and Python code examples in the `Instructions/Exercises/02-qna.md` file.

Improvements to loop termination:

* [`Instructions/Exercises/02-qna.md`](diffhunk://#diff-5f96619af56afaac3feb9a73007981141167a89b4f37bcc69faf1a04534f2c8fL215-R220): Modified the C# example to use a `while (true)` loop and added a conditional `break` statement to exit the loop when the user inputs "quit".
* [`Instructions/Exercises/02-qna.md`](diffhunk://#diff-5f96619af56afaac3feb9a73007981141167a89b4f37bcc69faf1a04534f2c8fL236-R241): Modified the Python example to use a `while True` loop and added a conditional `break` statement to exit the loop when the user inputs "quit".