### PR TITLE
LAB07 : Fix variable name for output file in speech synthesis example

### DIFF
--- a/Instructions/Labs/07-speech.md
+++ b/Instructions/Labs/07-speech.md
@@ -236,7 +236,7 @@ Speech Synthesis Markup Language (SSML) enables you to customize the way your sp
    if speak.reason != speech_sdk.ResultReason.SynthesizingAudioCompleted:
        print(speak.reason)
    else:
-       print("Spoken output saved in " + outputFile)
+       print("Spoken output saved in " + output_file)
     ```
 
 1. Save your changes and re-run the program, which should once again indicate that the spoken output was saved in a file.


### PR DESCRIPTION
This pull request includes a minor change to the `Instructions/Labs/07-speech.md` file. The change updates the variable name from `outputFile` to `output_file` for consistency with Python naming conventions.

This PR fix the issue #87 