### PR TITLE
fix(speech): replace AudioConfig with AudioOutputConfig 

### DIFF
--- a/Instructions/Labs/08-translate-speech.md
+++ b/Instructions/Labs/08-translate-speech.md
@@ -259,7 +259,7 @@ In this exercise, you used audio files for the speech input and output. Let's se
             "hi": "hi-IN-MadhurNeural"
    }
    speech_config.speech_synthesis_voice_name = voices.get(targetLanguage)
-   audio_config_out = speech_sdk.audio.AudioConfig(use_default_speaker=True)
+   audio_config_out = speech_sdk.audio.AudioOutputConfig(use_default_speaker=True)
    speech_synthesizer = speech_sdk.SpeechSynthesizer(speech_config, audio_config_out)
    speak = speech_synthesizer.speak_text_async(translation).get()
    if speak.reason != speech_sdk.ResultReason.SynthesizingAudioCompleted:


### PR DESCRIPTION
This PR fixes a runtime error when using speech synthesis with the default speaker.

- Problem
Using `AudioConfig(use_default_speaker=True)` caused the following error:
`AudioConfig.init() got an unexpected keyword argument 'use_default_speaker'`

Solution
Replaced `AudioConfig` with `AudioOutputConfig` when configuring TTS output:
```python
audio_config_out = speech_sdk.audio.AudioOutputConfig(use_default_speaker=True)