### PR TITLE
Switched back to GFM, added missing LF in index.md, fixed workflow

### DIFF
--- a/.github/workflows/voice-live-web-files.yml
+++ b/.github/workflows/voice-live-web-files.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - 'main'
-      - 'voice-live-agent'  # Added current branch
+
     paths:
       - 'Labfiles/11-voice-live-agent/python/**'
 

--- a/_config.yml
+++ b/_config.yml
@@ -11,8 +11,11 @@ plugins:
   - jekyll-sitemap
   - jekyll-mentions
   - jemoji
-markdown: kramdown
-kramdown:
-  syntax_highlighter_opts:
-     disable : true
 title: Azure AI Language Exercises
+markdown: GFM
+
+#markdown: kramdown
+#kramdown:
+#  syntax_highlighter_opts:
+#     disable : true
+

--- a/index.md
+++ b/index.md
@@ -15,6 +15,7 @@ The following exercises are designed to provide you with a hands-on learning exp
 {% assign labs = site.pages | where_exp:"page", "page.url contains '/Instructions/Labs'" %}
 {% for activity in labs  %}
 <hr>
+
 ### [{{ activity.lab.title }}]({{ site.github.url }}{{ activity.url }})
 
 {{activity.lab.description}}


### PR DESCRIPTION
Switched back to GFM. Original issue in switching to GFM was missing line space between HTML and markdown elements. Removed the voice-live branch from the workflow triggers.