### PR TITLE
Add Azure Speech SDK to requirements

### DIFF
--- a/Labfiles/07-speech/Python/speaking-clock/requirements.txt
+++ b/Labfiles/07-speech/Python/speaking-clock/requirements.txt
@@ -1,2 +1,3 @@
 python-dotenv
 azure.core
+azure-cognitiveservices-speech


### PR DESCRIPTION
Added missing dependency in requirements.txt used in lab.

The lab command installs:
pip install -r requirements.txt

However the package azure-cognitiveservices-speech is not included in requirements.txt, causing errors for local setups.