### PR TITLE
Fix typos in deployment instructions for speech models

### DIFF
--- a/Instructions/Exercises/03-gen-ai-speech.md
+++ b/Instructions/Exercises/03-gen-ai-speech.md
@@ -59,7 +59,7 @@ To develop speech-enables apps, we're going to need speech-enabled models. Speci
 
 ### Deploy a speech-generation model
 
-1. Now you're ready to **Start building**. Select **Find models** (or on the **Discover** page, select the **Models** tab) to view the Microsoft Foundry model catalog.
+1. Now you're ready to **Start building**. Let's **Explore models** (or on the **Discover** page, select the **Models** tab) to view the Microsoft Foundry model catalog.
 1. In the model catalog, search for `gpt-4o-mini-tts`.
 1. Review the model card, and then deploy it using the default settings.
 1. When the model has been deployed, view its details, noting that the **Target URI** and **Key** required to use it are available here (you'll need the Target URI later).
@@ -67,7 +67,7 @@ To develop speech-enables apps, we're going to need speech-enabled models. Speci
 ### Deploy a speech-recognition model
 
 1. In the Foundry portal menu bar, select **Build**; and then view the **Deployments** page. Note that the *gpt-4o-mini-tts* model you deployed is listed.
-1. Select **Deploy a base model, and search the catalog for `gpt-4o-mini-transcribe`.
+1. Select **Deploy a base model**, and search the catalog for `gpt-4o-mini-transcribe`.
 1. Deploy a *gpt-4o-mini-transcribe* model using the default settings.
 1. Return to the **Deployments** page and verify that both of the model you deployed are listed.
 1. Select either of the models to view the Target URI you need to use in your code.

--- a/Instructions/Exercises/05-azure-speech-mcp.md
+++ b/Instructions/Exercises/05-azure-speech-mcp.md
@@ -115,7 +115,7 @@ Now that you have a Foundry project, you can create an agent.
 Foundry includes an MCP server for Azure Speech in Foundry Tools, which you can connect to your project and use in your agent.
 
 1. In the navigation pane on the left, select the **Tools** page.
-1. On the **Tolls** tab, connect a tool; selecting **Azure Speech MCP Server** in the **Catalog** and connecting it to an endpoint. specifying the following configuration
+1. On the **Tools** tab, connect a tool; selecting **Azure Speech MCP Server** in the **Catalog** and connecting it to an endpoint. specifying the following configuration
     - **Name**: *A unique name for your tool.*
     - **Remote MCP Server endpoint**: `https://{foundry-resource-name}.cognitiveservices.azure.com/speech/mcp?api-version=2025-11-15-preview`
     - **Parameters**: foundry-resource-name: *Your foundry resource name*


### PR DESCRIPTION
This pull request makes minor corrections to instructional text for deploying and configuring speech models and tools in the Foundry platform. The changes clarify instructions and fix typos to improve the user experience.

Instructional improvements:

* Clarified the step to explore models by changing "**Find models**" to "**Explore models**" in the speech-generation model deployment instructions, making the action more intuitive.
* Fixed a typo in the speech-recognition model deployment instructions by adding a missing comma and correcting the instruction to "**Select Deploy a base model, and search the catalog...**".
* Corrected a typo from "**Tolls**" to "**Tools**" in the instructions for connecting the Azure Speech MCP Server tool, ensuring consistency with the UI.