### PR TITLE
Add notes on recommended Microsoft Foundry regions for model availability

### DIFF
--- a/Instructions/Exercises/01-analyze-text.md
+++ b/Instructions/Exercises/01-analyze-text.md
@@ -46,6 +46,8 @@ Microsoft Foundry uses projects to organize models, resources, data, and other a
     - **Resource group**: *Create or select a resource group*
     - **Region**: Select any available region
 
+    > **Note**: Use a recommended Microsoft Foundry region. Model availability may vary by region.
+
 1. Select **Create**. Wait for your project to be created.
 1. On the home page for your project, note that the API key, project endpoint, and OpenAI endpoint are displayed here.
 

--- a/Instructions/Exercises/02-language-agent.md
+++ b/Instructions/Exercises/02-language-agent.md
@@ -44,6 +44,8 @@ Microsoft Foundry uses projects to organize models, resources, data, and other a
     - **Resource group**: *Create or select a resource group*
     - **Region**: Select any available region
 
+    > **Note**: Use a recommended Microsoft Foundry region. Model availability may vary by region.
+
     > **TIP**: Remember (or make a note of) the Foundry resource name - you're going to need it later!
 
 1. Select **Create**. Wait for your project to be created.

--- a/Instructions/Exercises/03-gen-ai-speech.md
+++ b/Instructions/Exercises/03-gen-ai-speech.md
@@ -60,17 +60,21 @@ To develop speech-enables apps, we're going to need speech-enabled models. Speci
 ### Deploy a speech-generation model
 
 1. Now you're ready to **Start building**. Let's **Explore models** (or on the **Discover** page, select the **Models** tab) to view the Microsoft Foundry model catalog.
-1. In the model catalog, search for `gpt-4o-mini-tts`.
-1. Review the model card, and then deploy it using the default settings.
+1. In the model catalog, search for `gpt-4o-mini-tts` or another text-to-speech model available in your region.
+1. Review the model card, and then deploy an available text-to-speech model using the default settings.
 1. When the model has been deployed, view its details, noting that the **Target URI** and **Key** required to use it are available here (you'll need the Target URI later).
+
+    > **IMPORTANT**: `gpt-4o-mini-tts` is a recommended model for this exercise, not a required one. If it is unavailable in your region, deploy a supported text-to-speech model instead.
 
 ### Deploy a speech-recognition model
 
-1. In the Foundry portal menu bar, select **Build**; and then view the **Deployments** page. Note that the *gpt-4o-mini-tts* model you deployed is listed.
-1. Select **Deploy a base model**, and search the catalog for `gpt-4o-mini-transcribe`.
-1. Deploy a *gpt-4o-mini-transcribe* model using the default settings.
+1. In the Foundry portal menu bar, select **Build**; and then view the **Deployments** page. Note that the text-to-speech model you deployed is listed.
+1. Select **Deploy a base model**, and search the catalog for `gpt-4o-mini-transcribe` or another speech-to-text model available in your region.
+1. Deploy an available speech-to-text model using the default settings.
 1. Return to the **Deployments** page and verify that both of the model you deployed are listed.
 1. Select either of the models to view the Target URI you need to use in your code.
+
+    > **IMPORTANT**: `gpt-4o-mini-transcribe` is a recommended model for this exercise, not a required one. If it is unavailable in your region, deploy a supported speech-to-text model instead.
 
 ## Get the application files from GitHub
 

--- a/Instructions/Exercises/04-azure-speech.md
+++ b/Instructions/Exercises/04-azure-speech.md
@@ -51,6 +51,8 @@ Microsoft Foundry uses projects to organize models, resources, data, and other a
     - **Resource group**: *Create or select a resource group*
     - **Region**: Select any available region
 
+    > **Note**: Use a recommended Microsoft Foundry region. Model availability may vary by region.
+
     > **TIP**: \* Remember the Foundry resource name - you'll need it later!
 
 1. Wait for your project to be created. Then view the home page for your project.

--- a/Instructions/Exercises/05-azure-speech-mcp.md
+++ b/Instructions/Exercises/05-azure-speech-mcp.md
@@ -79,6 +79,8 @@ Microsoft Foundry uses projects to organize models, resources, data, and other a
     - **Resource group**: *Create or select a resource group*
     - **Region**: Select any available region
 
+    > **Note**: Use a recommended Microsoft Foundry region. Model availability may vary by region.
+
     > **TIP**: Remember (or make a note of) the Foundry resource name - you're going to need it later!
 
 1. Wait for your project to be created.

--- a/Instructions/Exercises/06-voice-live-agent.md
+++ b/Instructions/Exercises/06-voice-live-agent.md
@@ -42,6 +42,8 @@ Microsoft Foundry uses projects to organize models, resources, data, and other a
     - **Resource group**: *Create or select a resource group*
     - **Region**: Select any available region
 
+    > **Note**: Use a recommended Microsoft Foundry region. Model and feature availability may vary by region.
+
 1. Select **Create**. Wait for your project to be created. Then view its home page.
 
 ## Create an agent

--- a/Instructions/Exercises/07-translation.md
+++ b/Instructions/Exercises/07-translation.md
@@ -49,6 +49,8 @@ Microsoft Foundry uses projects to organize models, resources, data, and other a
     - **Resource group**: *Create or select a resource group*
     - **Region**: Select any available region
 
+    > **Note**: Use a recommended Microsoft Foundry region. Model availability may vary by region.
+
     > **TIP**: \* Remember the Foundry resource name - you'll need it later!
 
 1. Wait for your project to be created. Then view the home page for your project.


### PR DESCRIPTION
This pull request updates several exercise instructions to clarify model and feature availability by region and to provide guidance when recommended models are not available. The main improvements ensure users select appropriate regions and models during deployment, improving the overall user experience and reducing confusion.

**Regional guidance and model availability:**

* Added notes in exercise instructions (`01-analyze-text.md`, `02-language-agent.md`, `04-azure-speech.md`, `05-azure-speech-mcp.md`, `06-voice-live-agent.md`, `07-translation.md`) to recommend using a Microsoft Foundry region and to clarify that model (and feature) availability may vary by region. [[1]](diffhunk://#diff-e347b951644ea3624e186d15c0f8879e98302070fd9121dec73c35c1e15aad0fR49-R50) [[2]](diffhunk://#diff-98cfd52f9974282b0df4bbad236417dc4a47ee618ade484efd710c76331eaa04R47-R48) [[3]](diffhunk://#diff-f6d95c965de55043d580f060939af5de0f080fd090c297e86f3ea28038bc2aa5R54-R55) [[4]](diffhunk://#diff-d4d740fd3b92f3babc99cffd043503c652719246c7a4a25d0cda782cfb15c4a9R82-R83) [[5]](diffhunk://#diff-15524e74b81dfe75d822e4d7b0184154870955e003a795f042839bd2015c80fbR45-R46) [[6]](diffhunk://#diff-e250e64a9d56b027dd1e8e5d86f474cba44712054c670ce212b355d05160ec0fR52-R53)

**Model deployment flexibility:**

* Updated exercise `03-gen-ai-speech.md` to instruct users to deploy an available text-to-speech or speech-to-text model if the recommended `gpt-4o-mini-tts` or `gpt-4o-mini-transcribe` models are not available in their region, and added important notes to clarify this flexibility.

NOTE: These changes are also to refer to an issue reported on the mslearn-ai-studio repo: https://github.com/MicrosoftLearning/mslearn-ai-studio/issues/187

I believe it was miss when reporting in that repo instead of this one, language was the one I remembered having the gpt-4o-mini-tts.