### PR TITLE
Fix ModuleNotFoundError: No module named 'httpx' in labs 02 and 05

### DIFF
--- a/Labfiles/02-language-agent/Python/text-agent/requirements.txt
+++ b/Labfiles/02-language-agent/Python/text-agent/requirements.txt
@@ -1,3 +1,5 @@
 python-dotenv
 azure-identity
 azure-ai-projects==2.0.0b4
+openai<3
+httpx

--- a/Labfiles/05-speech-tool/Python/speech-client/requirements.txt
+++ b/Labfiles/05-speech-tool/Python/speech-client/requirements.txt
@@ -1,3 +1,5 @@
 python-dotenv
 azure-identity
 azure-ai-projects==2.0.0b4
+openai<3
+httpx


### PR DESCRIPTION
Fixes #147

## Root cause

`azure-ai-projects==2.0.0b4` does `import httpx` at the top of `azure/ai/projects/_patch.py` (and uses `httpx.Client` / `httpx.HTTPTransport` when building the OpenAI client), but it does **not** declare `httpx` as a dependency — it relied on `openai` pulling it in transitively.

`azure-ai-projects==2.0.0b4` requires `openai>=2.8.0` with no upper bound, and `openai` 3.x replaced its `httpx` dependency with `httpx2`. So a fresh `pip install -r requirements.txt` now resolves openai 3.x, `httpx` is never installed, and `azure.ai.projects` fails with `ModuleNotFoundError: No module named 'httpx'`.

## Change

Added `openai<3` and `httpx` to the two Python labs that install **and** import `azure-ai-projects==2.0.0b4`:

- `Labfiles/02-language-agent/Python/text-agent/requirements.txt`
- `Labfiles/05-speech-tool/Python/speech-client/requirements.txt` (same latent failure, not yet reported)

The `openai<3` pin goes slightly beyond the issue's suggestion of adding only `httpx`, because the SDK passes an `httpx.Client` into the `OpenAI(...)` constructor and reads `client.user_agent`. openai 3.x is built on `httpx2`, so adding `httpx` alone would leave the labs on an untested major version with a mismatched HTTP client type.

`Labfiles/06-voice-live` installs `azure-ai-projects==2.0.0b4` in its exercise instructions but never imports it, so it is unaffected and left unchanged. No exercise markdown changes are needed — both exercises simply run `pip install -r requirements.txt`.

## Verification

Clean venv install of the updated lab 02 requirements:

```
Successfully installed ... azure-ai-projects-2.0.0b4 ... httpx-0.28.1 ... openai-2.54.0 ...

> python -c "from azure.ai.projects import AIProjectClient; import httpx, openai; print('OK', httpx.__version__, openai.__version__)"
OK 0.28.1 2.54.0
```